### PR TITLE
COMPAT: Don't allow the client application to free internal surfaces.

### DIFF
--- a/include/SDL_surface.h
+++ b/include/SDL_surface.h
@@ -55,6 +55,7 @@ extern "C" {
 /*@{*/
 #define SDL_PREALLOC        0x00000001  /**< Surface uses preallocated memory */
 #define SDL_RLEACCEL        0x00000002  /**< Surface is RLE encoded */
+#define SDL_DONTFREE        0x00000004  /**< Surface is referenced internally */
 /*@}*//*Surface flags*/
 
 /**

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -974,6 +974,9 @@ SDL_FreeSurface(SDL_Surface * surface)
     if (surface == NULL) {
         return;
     }
+    if (surface->flags & SDL_DONTFREE) {
+        return;
+    }
     if (--surface->refcount > 0) {
         return;
     }

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -477,6 +477,7 @@ extern int SDL_GetGammaRampForDisplay(SDL_VideoDisplay * display, Uint16 * red, 
 extern void SDL_AddRenderDriver(SDL_VideoDisplay *display, const SDL_RenderDriver * driver);
 
 extern int SDL_RecreateWindow(SDL_Window * window, Uint32 flags);
+extern void SDL_VideoQuitCompat(void);
 
 extern void SDL_OnWindowShown(SDL_Window * window);
 extern void SDL_OnWindowHidden(SDL_Window * window);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2825,6 +2825,9 @@ SDL_VideoQuit(void)
     if (!_this) {
         return;
     }
+
+    SDL_VideoQuitCompat();
+
     /* Halt event processing before doing anything else */
     SDL_StopEventLoop();
     SDL_EnableScreenSaver();


### PR DESCRIPTION
This is a custom and partial backport from SDL HG r5288.

The SDL_VideoQuitCompat bit should probably go upstream since it plugs some memory leaks when quitting SDL.
